### PR TITLE
Remove abandoned package

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,6 @@ LibTOAST.jl is a low-level interface to the TOAST++ library. (TOAST++ is an end-
 
 Programs in chapters 4, 5 and early sections of 6 as described in "Programming the Finite Element Method" by Smith, Griffiths and Margetts.
 
-### [https://github.com/jlchan/ESDG.jl](https://github.com/jlchan/ESDG.jl)
-A set of codes for solving 1D/2D/3D time-dependent hyperbolic PDEs using high order DG methods on conforming unstructured meshes of triangular, quadrilateral, or hexahedral elements. 
-
 ### [https://github.com/jlchan/NodesAndModes.jl](https://github.com/jlchan/NodesAndModes.jl)
 A collection of routines to compute high order "modal" and "nodal" basis functions and their derivatives on 1D, 2D (triangle, quadrilateral), and 3D (hexahedral, tetrahedral, wedge, pyramid) elements. Routines are also provided for quadrature rules and for computing optimized interpolation points. 
 


### PR DESCRIPTION
I'm the developer of ESDG.jl, which was a loose collection of demos rather than an actual library for finite elements. It hasn't been used for about 2 years now, so I'd suggest removing it.